### PR TITLE
Avoid warning when forced is integer(0).

### DIFF
--- a/R/GaussSuppressionFromData.R
+++ b/R/GaussSuppressionFromData.R
@@ -560,8 +560,10 @@ GaussSuppressionFromData = function(data, dimVar = NULL, freqVar=NULL,
   
   if(!is.null(forced)){
     if (!is.logical(forced)) {   # logical allowed in  SSBtools::GaussSuppression
-      if(min(forced) < 0 | max(forced) > m){
-        stop("forced input outside range")
+      if (length(forced)) {
+        if (min(forced) < 0 | max(forced) > m) {
+          stop("forced input outside range")
+        }
       }
       forcedA <- rep(FALSE, m)
       forcedA[forced] <- TRUE


### PR DESCRIPTION
After change this behavior continues:

`forced` is `integer(0)`: forced in output when `forcedInOutput` is `"ifNonNULL"` or `"always"`

`forced` is `NULL`: forced in output only when `forcedInOutput` is  `"always"`